### PR TITLE
[Design-Patterns] - Factory Pattern

### DIFF
--- a/DesignPatterns/Factory/factory-practice.swift
+++ b/DesignPatterns/Factory/factory-practice.swift
@@ -1,0 +1,131 @@
+import Foundation
+
+// Protocol definition with documentation
+protocol Document {
+    /// Opens the document from the specified file path
+    /// - Parameter filePath: The path to the document
+    func openDocument(filePath: String)
+    
+    /// Saves the document
+    func saveDocument()
+    
+    /// The file extension for this document type
+    var fileExtension: String { get }
+    
+    /// The size of the document in kilobytes
+    var fileSizeKB: Int { get }
+}
+
+// Error handling
+enum DocumentError: Error {
+    case unsupportedDocumentType
+    case invalidFilePath
+}
+
+// Document implementation
+class PDF: Document {
+    func openDocument(filePath: String) {
+        print("PDF file has been opened")
+        print("Reading file..")
+    }
+    
+    func saveDocument(){
+        print("PDF document has been saved")
+    }
+    
+    var fileExtension: String {
+        return ".pdf"
+    }
+    
+    var fileSizeKB: Int {
+        return 32
+    }
+}
+
+class Word: Document {
+    func openDocument(filePath: String) {
+        print("Word document has been opened")
+        print("Reading file...")
+    }
+    
+    func saveDocument(){
+        print("Word document has been saved")
+    }
+    
+    var fileExtension: String {
+        return ".word"
+    }
+    
+    var fileSizeKB: Int {
+        return 64
+    }
+}
+
+class Text: Document {
+    func openDocument(filePath: String) {
+        print("Text document has been opened")
+        print("Reading file...")
+    }
+    
+    func saveDocument() {
+        print("Text document has been saved")
+    }
+    
+    var fileExtension: String {
+        return ".txt"
+    }
+    
+    var fileSizeKB: Int {
+        return 16
+    }
+}
+
+enum DocumentType {
+    case pdf
+    case word
+    case txt
+}
+
+// Factory
+class DocumentFactory {
+    static func createDocument(fileExtension: DocumentType) throws -> Document {
+        switch fileExtension {
+        case .pdf:
+            return PDF()
+        case .word:
+            return Word()
+        case .txt:
+            return Text()
+        }
+    }
+}
+
+// Processor
+class DocumentProcessor {
+    private let document: Document
+    
+    init(documentType: DocumentType) throws {
+        self.document = try DocumentFactory.createDocument(fileExtension: documentType)
+    }
+    
+    func processDocument(filePath: String) throws {
+        guard !filePath.isEmpty else {
+            throw DocumentError.invalidFilePath
+        }
+        
+        document.openDocument(filePath: filePath)
+        document.saveDocument()
+        
+        print("Processing complete: ")
+        print("- Size: \(document.fileSizeKB)KB")
+        print("- Extension: \(document.fileExtension)")
+    }
+}
+
+// Example of usage
+do {
+    let pdfProcessor = try DocumentProcessor(documentType: .pdf)
+    try pdfProcessor.processDocument(filePath: "example/path/document")
+} catch {
+    print("Error creating document: \(error)")
+}

--- a/DesignPatterns/Factory/factory.swift
+++ b/DesignPatterns/Factory/factory.swift
@@ -1,0 +1,75 @@
+import Foundation
+
+protocol PaymentMethod {
+    func processPayment(amount: Double)
+    var fee: Double { get }
+}
+
+class CreditCard: PaymentMethod {
+    func processPayment(amount: Double) {
+        print("Processing credit card payment of $\(amount)")
+        print("Fee applied: $\(fee)")
+    }
+    
+    var fee: Double {
+        return 2.5
+    }
+}
+
+class PayPal: PaymentMethod {
+    func processPayment(amount: Double) {
+        print("Processing PayPal payment of $\(amount)")
+        print("Fee applied: $\(fee)")
+    }
+    
+    var fee: Double {
+        return 3.0
+    }
+}
+
+class BankTransfer: PaymentMethod {
+    func processPayment(amount: Double) {
+        print("Processing bank transfer of $\(amount)")
+        print("Fee applied: $\(fee)")
+    }
+    
+    var fee: Double {
+        return 1.0
+    }
+}
+
+// Create the Factory
+
+enum PaymentMethodType {
+    case creditCard
+    case paypal
+    case bankTransfer
+}
+
+class PaymentMethodFactory {
+    static func createPaymentMethod(type: PaymentMethodType) -> PaymentMethod {
+        switch type {
+        case .creditCard:
+            return CreditCard()
+        case .paypal:
+            return PayPal()
+        case .bankTransfer:
+            return BankTransfer()
+        }
+    }
+}
+
+class PaymentProcessor {
+    func processPayment(amount: Double, methodType: PaymentMethodType) {
+        let paymentMethod = PaymentMethodFactory.createPaymentMethod(type: methodType)
+        paymentMethod.processPayment(amount: amount)
+    }
+}
+
+// Example usage
+
+let processor = PaymentProcessor()
+
+processor.processPayment(amount: 100.0, methodType: .creditCard)
+processor.processPayment(amount: 50.0, methodType: .paypal)
+processor.processPayment(amount: 1000.0, methodType: .bankTransfer)

--- a/DesignPatterns/Factory/factory.swift
+++ b/DesignPatterns/Factory/factory.swift
@@ -38,12 +38,25 @@ class BankTransfer: PaymentMethod {
     }
 }
 
+// New payment method
+class ApplePay: PaymentMethod {
+    func processPayment(amount: Double) {
+        print("Processing Apple Pay payment of $\(amount)")
+        print("Fee applied: $\(fee)")
+    }
+    
+    var fee: Double {
+        return 1.5
+    }
+}
+
 // Create the Factory
 
 enum PaymentMethodType {
     case creditCard
     case paypal
     case bankTransfer
+    case applePay
 }
 
 class PaymentMethodFactory {
@@ -55,6 +68,8 @@ class PaymentMethodFactory {
             return PayPal()
         case .bankTransfer:
             return BankTransfer()
+        case .applePay:
+            return ApplePay()
         }
     }
 }
@@ -73,3 +88,4 @@ let processor = PaymentProcessor()
 processor.processPayment(amount: 100.0, methodType: .creditCard)
 processor.processPayment(amount: 50.0, methodType: .paypal)
 processor.processPayment(amount: 1000.0, methodType: .bankTransfer)
+processor.processPayment(amount: 350, methodType: .applePay)


### PR DESCRIPTION
# Factory Pattern
The Factory pattern allows us to create objects without explicitly specifying their exact classes.

```
// Without Factory pattern (direct instantiation)
let payment = CreditCard() // We explicitly choose CreditCard at compile time

// With Factory pattern
let payment = PaymentMethodFactory.createPaymentMethod(type: selectedType) // Type determined at runtime
```

For example: 
- User sees payment options
- User selects PayPal
- At runtime, the Factory creates a PayPal payment object without the app needing to know the specific implementation details